### PR TITLE
Add event and async send of commands to DCS-BIOS

### DIFF
--- a/src/DCS-BIOS/EventArgs/BIOSEventHandler.cs
+++ b/src/DCS-BIOS/EventArgs/BIOSEventHandler.cs
@@ -132,5 +132,31 @@ namespace DCS_BIOS.EventArgs
         {
             OnDCSBIOSStringReceived?.Invoke(sender, new DCSBIOSStringDataEventArgs { Address = address, StringData = data });
         }
+
+        /*
+         * For listening on what DCS-BIOS commands are sent.
+         */
+        public delegate void DCSBIOSCommandSent(DCSBIOSCommandEventArgs e);
+        public static event DCSBIOSCommandSent OnDCSBIOSCommandSent;
+
+        public static bool OnDCSBIOSCommandSentEventSubscribed()
+        {
+            return OnDCSBIOSCommandSent != null && OnDCSBIOSCommandSent.GetInvocationList().Length > 0;
+        }
+
+        public static void AttachCommandSentListener(IDCSBiosCommandListener commandListener)
+        {
+            OnDCSBIOSCommandSent += commandListener.DCSBIOSCommandSent;
+        }
+
+        public static void DetachCommandSentListener(IDCSBiosCommandListener commandListener)
+        {
+            OnDCSBIOSCommandSent -= commandListener.DCSBIOSCommandSent;
+        }
+
+        public static void DCSBIOSCommandWasSent(string command)
+        {
+            OnDCSBIOSCommandSent?.Invoke(new DCSBIOSCommandEventArgs { Command = command });
+        }
     }
 }

--- a/src/DCS-BIOS/EventArgs/DCSBIOSCommandEventArgs.cs
+++ b/src/DCS-BIOS/EventArgs/DCSBIOSCommandEventArgs.cs
@@ -1,0 +1,7 @@
+﻿namespace DCS_BIOS.EventArgs
+{
+    public class DCSBIOSCommandEventArgs : System.EventArgs                 
+    {
+        public string Command { get; init; }
+    }
+}

--- a/src/DCS-BIOS/Interfaces/IDCSBiosCommandListener.cs
+++ b/src/DCS-BIOS/Interfaces/IDCSBiosCommandListener.cs
@@ -1,0 +1,9 @@
+﻿namespace DCS_BIOS.Interfaces
+{
+    using EventArgs;
+
+    public interface IDCSBiosCommandListener
+    {
+        void DCSBIOSCommandSent(DCSBIOSCommandEventArgs e);
+    }
+}

--- a/src/DCS-BIOS/Serialized/DCSBIOSInputInterface.cs
+++ b/src/DCS-BIOS/Serialized/DCSBIOSInputInterface.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using ClassLibraryCommon;
 using DCS_BIOS.Json;
 
@@ -61,9 +62,9 @@ namespace DCS_BIOS.Serialized
             return command;
         }
 
-        public void SendCommand()
+        public async Task SendCommand()
         {
-            DCSBIOS.Send(GetDCSBIOSCommand());
+            await DCSBIOS.Send(GetDCSBIOSCommand());
         }
 
         public int Delay { get; set; }

--- a/src/DCS-BIOS/misc/DCSBIOSConstants.cs
+++ b/src/DCS-BIOS/misc/DCSBIOSConstants.cs
@@ -6,5 +6,17 @@
         public const int META_MODULE_ID_START_RANGE = 500;
         public const uint META_MODULE_START_ADDRESS = 0x0000;
         public const uint META_MODULE_END_ADDRESS = 0xfffe;
+
+
+        public const int MS100 = 100;
+        public const int MS200 = 200;
+        public const int MS300 = 300;
+        public const int MS400 = 400;
+        public const int MS500 = 500;
+        public const int MS600 = 600;
+        public const int MS700 = 700;
+        public const int MS800 = 800;
+        public const int MS900 = 900;
+        public const int MS1000 = 1000;
     }
 }


### PR DESCRIPTION
A new event can be subscribed to for listening to DCS-BIOS commands having been sent. The whole sending of commands now is async and using a channel in a task that is started when DCS-BIOS starts.